### PR TITLE
rewrite imports to point internally

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,11 +18,11 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/cznic/b"
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/hrpc"
-	"github.com/tsuna/gohbase/pb"
-	"github.com/tsuna/gohbase/region"
-	"github.com/tsuna/gohbase/regioninfo"
-	"github.com/tsuna/gohbase/zk"
+	"github.com/Flipboard/gohbase/hrpc"
+	"github.com/Flipboard/gohbase/pb"
+	"github.com/Flipboard/gohbase/region"
+	"github.com/Flipboard/gohbase/regioninfo"
+	"github.com/Flipboard/gohbase/zk"
 	"golang.org/x/net/context"
 )
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -9,7 +9,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/tsuna/gohbase"
+	"github.com/Flipboard/gohbase"
 	"golang.org/x/net/context"
 )
 

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -9,8 +9,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/tsuna/gohbase/pb"
-	"github.com/tsuna/gohbase/regioninfo"
+	"github.com/Flipboard/gohbase/pb"
+	"github.com/Flipboard/gohbase/regioninfo"
 )
 
 func TestRegionDiscovery(t *testing.T) {

--- a/filter/comparator.go
+++ b/filter/comparator.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/pb"
 )
 
 const comparatorPath = "org.apache.hadoop.hbase.filter."

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/pb"
 )
 
 const filterPath = "org.apache.hadoop.hbase.filter."

--- a/hrpc/call.go
+++ b/hrpc/call.go
@@ -10,9 +10,9 @@ import (
 	"unsafe"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/filter"
-	"github.com/tsuna/gohbase/pb"
-	"github.com/tsuna/gohbase/regioninfo"
+	"github.com/Flipboard/gohbase/filter"
+	"github.com/Flipboard/gohbase/pb"
+	"github.com/Flipboard/gohbase/regioninfo"
 	"golang.org/x/net/context"
 )
 

--- a/hrpc/create.go
+++ b/hrpc/create.go
@@ -7,7 +7,7 @@ package hrpc
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/pb"
 	"golang.org/x/net/context"
 )
 

--- a/hrpc/delete.go
+++ b/hrpc/delete.go
@@ -7,7 +7,7 @@ package hrpc
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/pb"
 	"golang.org/x/net/context"
 )
 

--- a/hrpc/disable.go
+++ b/hrpc/disable.go
@@ -7,7 +7,7 @@ package hrpc
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/pb"
 	"golang.org/x/net/context"
 )
 

--- a/hrpc/enable.go
+++ b/hrpc/enable.go
@@ -7,7 +7,7 @@ package hrpc
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/pb"
 	"golang.org/x/net/context"
 )
 

--- a/hrpc/get.go
+++ b/hrpc/get.go
@@ -7,8 +7,8 @@ package hrpc
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/filter"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/filter"
+	"github.com/Flipboard/gohbase/pb"
 	"golang.org/x/net/context"
 )
 

--- a/hrpc/hrpc_test.go
+++ b/hrpc/hrpc_test.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/tsuna/gohbase/filter"
-	"github.com/tsuna/gohbase/regioninfo"
+	"github.com/Flipboard/gohbase/filter"
+	"github.com/Flipboard/gohbase/regioninfo"
 	"golang.org/x/net/context"
 )
 

--- a/hrpc/mutate.go
+++ b/hrpc/mutate.go
@@ -15,8 +15,8 @@ import (
 	"unsafe"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/filter"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/filter"
+	"github.com/Flipboard/gohbase/pb"
 	"golang.org/x/net/context"
 )
 

--- a/hrpc/scan.go
+++ b/hrpc/scan.go
@@ -7,8 +7,8 @@ package hrpc
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/filter"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/filter"
+	"github.com/Flipboard/gohbase/pb"
 	"golang.org/x/net/context"
 )
 

--- a/hrpc/tableop.go
+++ b/hrpc/tableop.go
@@ -8,7 +8,7 @@ package hrpc
 import (
 	"errors"
 
-	"github.com/tsuna/gohbase/filter"
+	"github.com/Flipboard/gohbase/filter"
 )
 
 // tableOp represents an administrative operation on a table.

--- a/integration_test.go
+++ b/integration_test.go
@@ -16,9 +16,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tsuna/gohbase"
-	"github.com/tsuna/gohbase/hrpc"
-	"github.com/tsuna/gohbase/test"
+	"github.com/Flipboard/gohbase"
+	"github.com/Flipboard/gohbase/hrpc"
+	"github.com/Flipboard/gohbase/test"
 	"golang.org/x/net/context"
 )
 

--- a/metacache_test.go
+++ b/metacache_test.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/tsuna/gohbase/region"
-	"github.com/tsuna/gohbase/regioninfo"
+	"github.com/Flipboard/gohbase/region"
+	"github.com/Flipboard/gohbase/regioninfo"
 )
 
 func TestMetaCache(t *testing.T) {

--- a/region/client.go
+++ b/region/client.go
@@ -16,8 +16,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/hrpc"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/hrpc"
+	"github.com/Flipboard/gohbase/pb"
 )
 
 // ClientType is a type alias to represent the type of this region client

--- a/regioninfo/info.go
+++ b/regioninfo/info.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/pb"
 )
 
 // Info describes a region.

--- a/regioninfo/info_test.go
+++ b/regioninfo/info_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/tsuna/gohbase/pb"
-	. "github.com/tsuna/gohbase/regioninfo"
+	"github.com/Flipboard/gohbase/pb"
+	. "github.com/Flipboard/gohbase/regioninfo"
 )
 
 // Test parsing the contents of a cell found in meta.

--- a/test/test.go
+++ b/test/test.go
@@ -14,8 +14,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/tsuna/gohbase"
-	"github.com/tsuna/gohbase/hrpc"
+	"github.com/Flipboard/gohbase"
+	"github.com/Flipboard/gohbase/hrpc"
 	"golang.org/x/net/context"
 )
 

--- a/zk/client.go
+++ b/zk/client.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/samuel/go-zookeeper/zk"
-	"github.com/tsuna/gohbase/pb"
+	"github.com/Flipboard/gohbase/pb"
 )
 
 // ResourceName is a type alias that is used to represent different resources


### PR DESCRIPTION
Our patch is in the `region` package, so the `gohbase` package needs to import _our_ `region`, not `github.com/tsuna/gohbase/region`. To be consistent, let's just do that everywhere.

@hzhaofb @ascarter @dcreemer
